### PR TITLE
Add Non-Amazon Image Attribute Check

### DIFF
--- a/functions/domEvaluator.js
+++ b/functions/domEvaluator.js
@@ -39,7 +39,7 @@ function evaluateImageUrl(dom, platform, attribute) {
 
     switch (platform) {
         case 'flipkart': return JSON.parse(dom.window.document.getElementById("jsonLD") ? dom.window.document.getElementById("jsonLD").innerHTML : [{ image: '' }])[0].image;
-        case 'amazon': return dom.window.document.querySelector(attribute).getAttribute('data-old-hires');
+        case 'amazon': return dom.window.document.querySelector(attribute) ? dom.window.document.querySelector(attribute).getAttribute('data-old-hires') : '';
         case 'myntra': return '';
         default: return '';
     }


### PR DESCRIPTION
### Type
- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change
- [ ] Others

### Description
(Any relevant details regarding the change)
Image attribute check for non-amazon URLs was not handled correctly.